### PR TITLE
test: rtd PR build & linkcode uses commit hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Test RTD PR build and check that linkcode links as expected.
+
 [![os][os_img]][os_target]
 [![python][python_img]][python_target]
 [![pypi][pypi_img]][pypi_target]


### PR DESCRIPTION
This is a simple test to check RTD PR build option and linkcode links.