### PR TITLE
style: emoji tooltip arrow above shadow + sync with emoji shadow

### DIFF
--- a/docs/src/_static/custom.css
+++ b/docs/src/_static/custom.css
@@ -55,7 +55,7 @@ div.sphx-glr-download a:hover {
   transform: translateX(-50%) translateY(2px);
   border: 5px solid transparent;
   border-top-color: #333;
-  transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
   pointer-events: none;
   z-index: 1000;
   opacity: 0;
@@ -75,9 +75,9 @@ div.sphx-glr-download a:hover {
   border-radius: 3px;
   white-space: nowrap;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
-  transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
   pointer-events: none;
-  z-index: 1000;
+  z-index: 999;
   opacity: 0;
   visibility: hidden;
 }


### PR DESCRIPTION
### Arrow tipBefore
<img width="682" height="391" alt="image" src="https://github.com/user-attachments/assets/50b1d913-f203-4fc4-971d-fd7d53712f49" />

After
<img width="648" height="386" alt="image" src="https://github.com/user-attachments/assets/b064b491-27b8-4698-9346-4c864f76332c" />

### Sync
Now appears with shadow instead of background. Personal preference.