### PR TITLE
fix: Windows OpenMP duplicate issue + tutorials `torch.hub` rate limit issues (monkeypatch)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,6 @@ Possible contribution values are: `answering questions`, `bug reports`, `code`, 
 |-----------------|---------------|-----------------|
 | Sebastienlejeune | infrastructure | Lejeune, Sébastien |
 | ego-thales | bug reports, code, documentation, fixes, ideas, maintenance, pr reviews, testing, tutorials | Goudout, Élie |
-| eliegoudout | documentation, fixes | Goudout, Élie |
+| eliegoudout | bug reports, documentation, fixes, maintenance | Goudout, Élie |
 | Lap0u | fixes | Beaurain, Clément |
 <!-- TABLE END -->

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,9 +1,9 @@
 """For ruff :)."""
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 import html
 import importlib
 import inspect
@@ -11,6 +11,7 @@ import os
 import re
 from collections.abc import Mapping, Sequence
 from enum import EnumType
+from functools import partial
 from itertools import zip_longest
 from operator import itemgetter
 from os.path import dirname, relpath
@@ -19,6 +20,7 @@ from time import perf_counter
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal, cast
 
+import torch
 from paramclasses import IMPL, MISSING, isparamclass
 from sphinx.application import Sphinx
 from sphinx.util import logging
@@ -297,6 +299,9 @@ def linkcode_resolve(
 
 # -- Options for "sphinx_gallery.gen_gallery" --------------------------------
 os.environ.setdefault("HF_DATASETS_DISABLE_PROGRESS_BARS", "true")  # No download logs
+# Monkeypatch for github.com/ThalesGroup/scio/issues/11
+torch.hub.load = partial(torch.hub.load, skip_validation=True)
+
 tutorials_order = [
     "inferring_with_confidence.py",
     "visualizing_and_evaluating_ood_detection_algorithms.py",

--- a/docs/src/user_guide/installation_compatibility.rst
+++ b/docs/src/user_guide/installation_compatibility.rst
@@ -18,7 +18,7 @@ If you wish to install from source or wheels manually, you can download `release
 
 OS Compatibility
 ----------------
-The library is available and functional on **Ubuntu**, **Windows** and *MacOS* (minus ``faiss``-related features ─ feel free to show your interest `here <https://github.com/ThalesGroup/scio/issues/2>`_).
+The library is available and functional on **Ubuntu**, **Windows** and *MacOS* (minus ``faiss``-related features ─ feel free to show your interest `here <https://github.com/ThalesGroup/scio/issues/2>`__).
 
 Framework Compatiblity
 ----------------------
@@ -26,7 +26,7 @@ Although confidence scores are not a particularity of Neural Networks, ``scio`` 
 
 GPU Compatibility
 -----------------
-Our library is **fully compatible** and tested with CUDA devices for native use of GPU acceleration! Note however that features using ``faiss`` currently use CPU-bound indexes, introducing a potential GPU > CPU > GPU bottleneck. This may be improved in future versions ─ feel free to show your interest `here <https://github.com/ThalesGroup/scio/issues/18>`_.
+Our library is **fully compatible** and tested with CUDA devices for native use of GPU acceleration! Note however that features using ``faiss`` currently use CPU-bound indexes, introducing a potential GPU > CPU > GPU bottleneck. This may be improved in future versions ─ feel free to show your interest `here <https://github.com/ThalesGroup/scio/issues/18>`__.
 
 Supported Data Types
 --------------------

--- a/docs/src/user_guide/installation_compatibility.rst
+++ b/docs/src/user_guide/installation_compatibility.rst
@@ -18,10 +18,7 @@ If you wish to install from source or wheels manually, you can download `release
 
 OS Compatibility
 ----------------
-The library is available and functional on Ubuntu, Windows and MacOS. However, note the following regarding ``faiss``-related features.
-
-- They are **partially** supported on **Windows** and their use will trigger a warning: due to non-Python dependency conflicts, there might be uncontrolled and silent concurrency issues, potentially altering results. For more information, see this nice ressource about `native dependencies <https://pypackaging-native.github.io/key-issues/native-dependencies>`_. Note that we still run full CI tests on Windows.
-- They are **not officially supported** on **MacOS** and might generate random crashes. We should match the current Windows support status *relatively soon*.
+The library is available and functional on **Ubuntu**, **Windows** and *MacOS* (minus ``faiss``-related features ─ feel free to show your interest `here <https://github.com/ThalesGroup/scio/issues/2>`_).
 
 Framework Compatiblity
 ----------------------
@@ -29,10 +26,10 @@ Although confidence scores are not a particularity of Neural Networks, ``scio`` 
 
 GPU Compatibility
 -----------------
-Our library is **fully compatible** and tested with CUDA devices for native use of GPU acceleration! Note however that features using ``faiss`` currently use CPU-bound indexes, introducing a potential GPU > CPU > GPU bottleneck. This may be improved in future versions. Do not hesitate to express interest by opening a related issue.
+Our library is **fully compatible** and tested with CUDA devices for native use of GPU acceleration! Note however that features using ``faiss`` currently use CPU-bound indexes, introducing a potential GPU > CPU > GPU bottleneck. This may be improved in future versions ─ feel free to show your interest `here <https://github.com/ThalesGroup/scio/issues/18>`_.
 
 Supported Data Types
 --------------------
 The package is **fully compatible** and tested with ``torch.half`` (float16), ``torch.float`` (float32) and ``torch.double`` (float64) data types. However, we **discourage** the use of gradient-based algorithms with ``torch.half`` data, as they can easily generate irrelevant results due to potential ``nan`` values. Finally, note that ``faiss``-related operations temporarily convert to 32 bits data, regardless of the input type.
 
-There is currently no official support for ``torch.bfloat16`` even though many features may be compatible. Do not hesitate to express interest by opening a related issue.
+There is currently no official support for ``torch.bfloat16`` even though many features may be compatible. Feel free to show your interest by opening a related issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "dill>=0.3.8",
-    "faiss-cpu>=1.11",
+    "faiss-cpu>=1.12",
     "lazy-loader>=0.4",
     "matplotlib>=3.10",
     "numpy>=2.2.2",

--- a/scio/__init__.py
+++ b/scio/__init__.py
@@ -1,7 +1,5 @@
 """scio package."""
 
-import os
-import platform
 from importlib.metadata import PackageNotFoundError, version
 
 try:
@@ -13,48 +11,3 @@ import lazy_loader as lazy
 
 # Lazily load from adjacent `.pyi` file
 __getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)
-
-# Monkeypatch the use of ``faiss`` on non-Linux platforms
-if (
-    platform.system() != "Linux"
-    and os.environ.get("KMP_DUPLICATE_LIB_OK", None) != "TRUE"
-):  # pragma: no cover
-    import importlib
-    import sys
-    import types
-    from warnings import warn
-
-    null = object()
-
-    class DummyFaiss(types.ModuleType):
-        """Dummy faiss to intercept faiss loading."""
-
-        __faiss = null
-
-        def __getattribute__(self, attr: str) -> object:
-            """Intercept loading, warn & enable KMP_DUPLICATE_LIB_OK."""
-            __faiss = super().__getattribute__(f"_{type(self).__name__}__faiss")
-
-            # If necessary, warn and load faiss
-            if __faiss is null:
-                msg = (
-                    "On non-Linux platforms, the use of any `faiss`-dependant feature "
-                    "is partially supported by `scio`: you might experience slowdowns "
-                    "or even incorrect results! This is due to a non-Python dependency "
-                    "conflict regarding OpenMP (see https://pypackaging-native.github"
-                    ".io/key-issues/native-dependencies for interesting ressources). "
-                    "As a monkeypatch, we enable the `KMP_DUPLICATE_LIB_OK`."
-                )
-                warn(msg, stacklevel=2)
-                os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
-
-                if sys.modules.pop("faiss") is not self:
-                    msg = "Dummy faiss module should only be defined during scio init"
-                    raise RuntimeError(msg)
-
-                self.__faiss = __faiss = importlib.import_module("faiss")
-                sys.modules["faiss"] = __faiss
-
-            return __faiss.__getattribute__(attr)
-
-    sys.modules["faiss"] = DummyFaiss("faiss")

--- a/uv.lock
+++ b/uv.lock
@@ -347,30 +347,30 @@ wheels = [
 
 [[package]]
 name = "faiss-cpu"
-version = "1.11.0.post1"
+version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/f4/7c2136f4660ca504266cc08b38df2aa1db14fea93393b82e099ff34d7290/faiss_cpu-1.11.0.post1.tar.gz", hash = "sha256:06b1ea9ddec9e4d9a41c8ef7478d493b08d770e9a89475056e963081eed757d1", size = 70543, upload-time = "2025-07-15T09:15:02.127Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/80/bb75a7ed6e824dea452a24d3434a72ed799324a688b10b047d441d270185/faiss_cpu-1.12.0.tar.gz", hash = "sha256:2f87cbcd603f3ed464ebceb857971fdebc318de938566c9ae2b82beda8e953c0", size = 69292, upload-time = "2025-08-13T06:07:26.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/1e/9980758efa55b4e7a5d6df1ae17c9ddbe5a636bfbf7d22d47c67f7a530f4/faiss_cpu-1.11.0.post1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:68f6ce2d9c510a5765af2f5711bd76c2c37bd598af747f3300224bdccf45378c", size = 7913676, upload-time = "2025-07-15T09:14:06.077Z" },
-    { url = "https://files.pythonhosted.org/packages/05/d1/bd785887085faa02916c52320527b8bb54288835b0a3138df89a0e323cc8/faiss_cpu-1.11.0.post1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b940c530a8236cc0b9fd9d6e87b3d70b9c6c216bc2baf2649356c908902e52c9", size = 3313952, upload-time = "2025-07-15T09:14:07.584Z" },
-    { url = "https://files.pythonhosted.org/packages/89/13/d62ee83c5a0db24e9c4fc0a446949f9c8feca18659f4c17caca6c3d02867/faiss_cpu-1.11.0.post1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fafae1dcbcba3856a0bb82ffb0c3cae5922bdd6566fdd3b7feb2425cf4fca247", size = 3785328, upload-time = "2025-07-15T09:14:09.397Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a9/acfdd5bd63eff99188d0587fa6de4c30092ce952a1c7229e2fd5c84499d4/faiss_cpu-1.11.0.post1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d1262702c19aba2d23144b73f4b5730ca988c1f4e43ecec87edf25171cafe3d", size = 31287778, upload-time = "2025-07-15T09:14:11.252Z" },
-    { url = "https://files.pythonhosted.org/packages/88/96/195aecb139db223824a6b2faf647fbe622732659c100cdeca172679cc621/faiss_cpu-1.11.0.post1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:925feb69c06bfcc7f28869c99ab172f123e4b9d97a7e1353316fcc2748696f5b", size = 9714469, upload-time = "2025-07-15T09:14:18.497Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/0c/483d5233c41f753da6710e7026c0f7963649f6ecd1877d63c88cb204c8dc/faiss_cpu-1.11.0.post1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:00a837581b675f099c80c8c46908648dcf944a8992dd21e3887c61c6b110fe5f", size = 24012806, upload-time = "2025-07-15T09:14:20.679Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/17/4384518de0c58f49e4483c6dfdd1bc54540c9d0d71ccfcc87f6b52adfcb9/faiss_cpu-1.11.0.post1-cp312-cp312-win_amd64.whl", hash = "sha256:8bbaef5b56d1b0c01357ee6449d464ea4e52732fdb53a40bb5b9d77923af905f", size = 14882869, upload-time = "2025-07-15T09:14:23.195Z" },
-    { url = "https://files.pythonhosted.org/packages/56/64/ec3823d4703fa704c5e8821a5990fd0485e024d80d813231df0c65b3e18f/faiss_cpu-1.11.0.post1-cp312-cp312-win_arm64.whl", hash = "sha256:57f85dbefe590f8399a95c07e839ee64373cfcc6db5dd35232a41137e3deefeb", size = 7852194, upload-time = "2025-07-15T09:14:25.501Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c2/28c147fec80609b6ce8578df27d7fafe02d97726df2d261c446176e6ceda/faiss_cpu-1.11.0.post1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:caedaddfbfe365e3f1a57d5151cf94ea7b73c0e4789caf68eae05e0e10ca9fbf", size = 7913678, upload-time = "2025-07-15T09:14:27.072Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/71/7b06a5294e1d597f721016c6286a0c6e9912ed235d5e5d3600d4fd100ba8/faiss_cpu-1.11.0.post1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:202d11f1d973224ca0bde13e7ee8b862b6de74287e626f9f8820b360e6253d12", size = 3313956, upload-time = "2025-07-15T09:14:29.061Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/15/ae1db1c42c8bef2cfc27b9d5a032b7723aafcc9420c656c19a7eaafd717b/faiss_cpu-1.11.0.post1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6086e25ef680301350d6db72db7315e3531582cf896a7ee3f26295b1da73c44", size = 3785332, upload-time = "2025-07-15T09:14:30.784Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0d/4538dfccb6e28fdfafd536b6f9c565ca6f5495272ae0c3f872259b29afc8/faiss_cpu-1.11.0.post1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b93131842996efbbf76f07dba1775d3a5f355f74b9ba34334f1149aef046b37f", size = 31287781, upload-time = "2025-07-15T09:14:32.791Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e5/82e3cf427f11380aae54706168974724409fdf9a8caa0894d2c1f454c627/faiss_cpu-1.11.0.post1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f26e3e93f537b2e1633212a1b0a7dab74d77825366ed575ca434dac2fa14cea6", size = 9714472, upload-time = "2025-07-15T09:14:35.537Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/f9/f518bd45a247fe241dc6196f3b96aef7270b3f1e1a98ebee35d8d66cc389/faiss_cpu-1.11.0.post1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4b0e03cd758d03012d88aa4a70e673d10b66f31f7c122adc0c8c323cad2e33", size = 24012805, upload-time = "2025-07-15T09:14:38.362Z" },
-    { url = "https://files.pythonhosted.org/packages/43/0a/7394ba0220d0e13be48d7c4c4d8ddd6a2a98f7960a38359157c88e045fe3/faiss_cpu-1.11.0.post1-cp313-cp313-win_amd64.whl", hash = "sha256:bc53fe59b546dbab63144dc19dcee534ad7a213db617b37aa4d0e33c26f9bbaf", size = 14882903, upload-time = "2025-07-15T09:14:41.148Z" },
-    { url = "https://files.pythonhosted.org/packages/18/50/acc117b601da14f1a79f7deda3fad49509265d6b14c2221687cabc378dad/faiss_cpu-1.11.0.post1-cp313-cp313-win_arm64.whl", hash = "sha256:9cebb720cd57afdbe9dd7ed8a689c65dc5cf1bad475c5aa6fa0d0daea890beb6", size = 7852193, upload-time = "2025-07-15T09:14:43.113Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/58/602ed184d35742eb240cbfea237bd214f2ae7f01cb369c39f4dff392f7c9/faiss_cpu-1.12.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9b54990fcbcf90e37393909d4033520237194263c93ab6dbfae0616ef9af242b", size = 8034413, upload-time = "2025-08-13T06:06:05.564Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/f84c3d0e022cdeb73ff8406a6834a7698829fa242eb8590ddf8a0b09357f/faiss_cpu-1.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a5f5bca7e1a3e0a98480d1e2748fc86d12c28d506173e460e6746886ff0e08de", size = 3362034, upload-time = "2025-08-13T06:06:07.091Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a4ba4d285ea4f9b0824bf31ebded3171da08bfcf5376f4771cc5481f72cd/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:016e391f49933875b8d60d47f282f2e93d8ea9f9ffbda82467aa771b11a237db", size = 3834319, upload-time = "2025-08-13T06:06:08.86Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c9/be4e52fd96be601fefb313c26e1259ac2e6b556fb08cc392db641baba8c7/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2e4963c7188f57cfba248f09ebd8a14c76b5ffb87382603ccd4576f2da39d74", size = 31421585, upload-time = "2025-08-13T06:06:10.643Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/aa/12c6723ce30df721a6bace21398559c0367c5418c04139babc2d26d8d158/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:88bfe134f8c7cd2dda7df34f2619448906624962c8207efdd6eb1647e2f5338b", size = 9762449, upload-time = "2025-08-13T06:06:13.373Z" },
+    { url = "https://files.pythonhosted.org/packages/67/15/ed2c9de47c3ebae980d6938f0ec12d739231438958bc5ab2d636b272d913/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9243ee4c224a0d74419040503f22bf067462a040281bf6f3f107ab205c97d438", size = 24156525, upload-time = "2025-08-13T06:06:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/6911de6b8fdcfa76144680c2195df6ce7e0cc920a8be8c5bbd2dfe5e3c37/faiss_cpu-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:6b8012353d50d9bc81bcfe35b226d0e5bfad345fdebe0da31848395ebc83816d", size = 18169636, upload-time = "2025-08-13T06:06:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/69/d2b0f434b0ae35344280346b58d2b9a251609333424f3289c54506e60c51/faiss_cpu-1.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:8b4f5b18cbe335322a51d2785bb044036609c35bfac5915bff95eadc10e89ef1", size = 8012423, upload-time = "2025-08-13T06:06:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4e/6be5fbd2ceccd87b168c64edeefa469cd11f095bb63b16a61a29296b0fdb/faiss_cpu-1.12.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c9c79b5f28dcf9b2e2557ce51b938b21b7a9d508e008dc1ffea7b8249e7bd443", size = 8034409, upload-time = "2025-08-13T06:06:22.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f0/658012a91a690d82f3587fd8e56ea1d9b9698c31970929a9dba17edd211e/faiss_cpu-1.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:0db6485bc9f32b69aaccf9ad520782371a79904dcfe20b6da5cbfd61a712e85f", size = 3362034, upload-time = "2025-08-13T06:06:24.052Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8b/9b355309d448e1a737fac31d45e9b2484ffb0f04f10fba3b544efe6661e4/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6db5532831791d7bac089fc580e741e99869122946bb6a5f120016c83b95d10", size = 3834324, upload-time = "2025-08-13T06:06:25.506Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/d229f6cdb9cbe03020499d69c4b431b705aa19a55aa0fe698c98022b2fef/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d57ed7aac048b18809af70350c31acc0fb9f00e6c03b6ed1651fd58b174882d", size = 31421590, upload-time = "2025-08-13T06:06:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/26/19/80289ba008f14c95fbb6e94617ea9884e421ca745864fe6b8b90e1c3fc94/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:26c29290e7d1c5938e5886594dc0a2272b30728351ca5f855d4ae30704d5a6cc", size = 9762452, upload-time = "2025-08-13T06:06:30.237Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e7/6cc03ead5e19275e34992419e2b7d107d0295390ccf589636ff26adb41e2/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b43d0c295e93a8e5f1dd30325caaf34d4ecb51f1e3d461c7b0e71bff3a8944b", size = 24156530, upload-time = "2025-08-13T06:06:32.23Z" },
+    { url = "https://files.pythonhosted.org/packages/34/90/438865fe737d65e7348680dadf3b2983bdcef7e5b7e852000e74c50a9933/faiss_cpu-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:a7c6156f1309bb969480280906e8865c3c4378eebb0f840c55c924bf06efd8d3", size = 18169604, upload-time = "2025-08-13T06:06:34.884Z" },
+    { url = "https://files.pythonhosted.org/packages/76/69/40a1d8d781a70d33c57ef1b4b777486761dd1c502a86d27e90ef6aa8a9f9/faiss_cpu-1.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:0b5fac98a350774a98b904f7a7c6689eb5cf0a593d63c552e705a80c55636d15", size = 8012523, upload-time = "2025-08-13T06:06:37.24Z" },
 ]
 
 [[package]]
@@ -1515,7 +1515,7 @@ wheels = [
 
 [[package]]
 name = "scio-pypi"
-version = "1.0.0rc2"
+version = "1.0.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },
@@ -1555,7 +1555,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dill", specifier = ">=0.3.8" },
-    { name = "faiss-cpu", specifier = ">=1.11" },
+    { name = "faiss-cpu", specifier = ">=1.12" },
     { name = "lazy-loader", specifier = ">=0.4" },
     { name = "matplotlib", specifier = ">=3.10" },
     { name = "numpy", specifier = ">=2.2.2" },


### PR DESCRIPTION
Before, we'd get the following upon using `faiss` features on Windows (without the monkeypatch):
```
OMP: Error #15: Initializing libomp140.x86_64.dll, but found libiomp5md.dll already initialized.
OMP: Hint This means that multiple copies of the OpenMP runtime have been linked into the program. That is dangerous, since it can degrade performance or cause incorrect results. The best thing to do is to ensure that only a single OpenMP runtime is linked into the process, e.g. by avoiding static linking of the OpenMP runtime in any library. As an unsafe, unsupported, undocumented workaround you can set the environment variable KMP_DUPLICATE_LIB_OK=TRUE to allow the program to continue to execute, but that may cause crashes or silently produce incorrect results. For more information, please see http://openmp.llvm.org/
```

It is now fixed thanks to `faiss-cpu>=1.12` explicitly adding OpenBLAS submodule.
